### PR TITLE
Return a valid send email response

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->
+
+# Screenshots (if appropriate):
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .pytest_cache
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .pytest_cache
 __pycache__
+.coverage
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+sudo: required
+dist: trusty
+python: '3.6'
+
+# before_install:
+
+cache:
+  - pip
+
+install:
+  - pip install pipenv==8.3.2
+  - pipenv install --dev --deploy
+
+script:
+  - make test
+  - pipenv run coverage report
+
+after_success:
+  - pipenv run codecov
+
+branches:
+  only:
+    - master

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ codestyle:
 	pipenv run pycodestyle .
 
 unit:
-	pipenv run python -m pytest
+	pipenv run python -m pytest --cov=sdc_mock_gov_notify --cov-report xml
 
 behave:
 	pipenv run behave

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ help:
 install-dev-deps:
 	pipenv install --dev
 
+fix-codestyle:
+	pipenv run autopep8 -i -r .
+
 codestyle:
 	pipenv run pycodestyle .
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: help
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+install-dev-deps:
+	pipenv install --dev
+
+codestyle:
+	pipenv run pycodestyle .
+
+unit:
+	pipenv run python -m pytest
+
+behave:
+	pipenv run behave
+
+test: install-dev-deps codestyle unit behave

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ nose = "*"
 "autopep8" = "*"
 codecov = "*"
 coverage = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,8 @@ flask-test = "*"
 pycodestyle = "*"
 nose = "*"
 "autopep8" = "*"
+codecov = "*"
+coverage = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "03ec90ec51b7bcbd092580270edb8a4bdb12fa584ac83f1a79867aa45e1e8782"
+            "sha256": "de5335348c46e321cf06d712b97952690394bc9f5a203aaa08983c8469e2c5de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -302,6 +302,14 @@
             ],
             "index": "pypi",
             "version": "==3.6.3"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+            ],
+            "index": "pypi",
+            "version": "==2.5.1"
         },
         "requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "804b5606ee4734aec33de973e17aa3d53e5c14e44f69b10cceb20faf517d9edd"
+            "sha256": "03ec90ec51b7bcbd092580270edb8a4bdb12fa584ac83f1a79867aa45e1e8782"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -116,6 +116,56 @@
                 "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
             ],
             "version": "==6.7"
+        },
+        "codecov": {
+            "hashes": [
+                "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
+                "sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4"
+            ],
+            "index": "pypi",
+            "version": "==2.0.15"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
+            ],
+            "index": "pypi",
+            "version": "==4.5.1"
         },
         "docopt": {
             "hashes": [
@@ -270,9 +320,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:e21e5561a85dcdf16b8520ae4daec7401c5c24558e0ce004f9b60be75c4b6957"
+                "sha256:72325e67fb85f6e9ad304c603d83626d1df684fdf0c7ab1f0352e71feeab69d8"
             ],
-            "version": "==1.2.9"
+            "version": "==1.2.10"
         },
         "urllib3": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SDC Mock GOV.UK Notify
 
+[![Build Status](https://travis-ci.org/ONSdigital/sdc-mock-gov-notify.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-mock-gov-notify)
+
 ## Motivation
 
 This service has been built to enable the testing of user journeys which

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ require email verification.
 ### GOV.UK Notify Endpoints
 
 #### `POST /gov_notify_api/v2/notifications/email`
-This end point receives _send email_ requests for the official GOV.UK Notify API
+This endpoint receives _send email_ requests for the official GOV.UK Notify API
 packages and adds them to the email inbox.
 
 ### Programatic Endpoints

--- a/features/environment.py
+++ b/features/environment.py
@@ -10,7 +10,11 @@ from sdc_mock_gov_notify import app
 def before_feature(context, _step):
     port = os.getenv("PORT", 3001)
     host = 'localhost'
-    command = f'pipenv run gunicorn -b {host}:{port} --workers 1 --timeout 60 sdc_mock_gov_notify:app'
+    command = 'pipenv run gunicorn' \
+              f'-b {host}:{port}' \
+              '--workers 1' \
+              '--timeout 60' \
+              'sdc_mock_gov_notify:app'
     context.app_url = f'http://{host}:{port}'
 
     print(f'Starting server with command {command}')
@@ -35,7 +39,7 @@ def _wait_for_server(test_url, retries):
             else:
                 print('retrying')
 
-        except:
+        except BaseException:
             print(f'retrying...')
             sleep(1)
             retries -= 1

--- a/features/environment.py
+++ b/features/environment.py
@@ -10,11 +10,11 @@ from sdc_mock_gov_notify import app
 def before_feature(context, _step):
     port = os.getenv("PORT", 3001)
     host = 'localhost'
-    command = 'pipenv run gunicorn' \
-              f'-b {host}:{port}' \
-              '--workers 1' \
-              '--timeout 60' \
-              'sdc_mock_gov_notify:app'
+    command = 'pipenv run gunicorn ' \
+              f'-b {host}:{port} ' \
+              '--workers 1 ' \
+              '--timeout 60 ' \
+              'sdc_mock_gov_notify:app '
     context.app_url = f'http://{host}:{port}'
 
     print(f'Starting server with command {command}')

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,6 +1,44 @@
+import os
+import subprocess
+from time import sleep
+
+import requests
+
 from sdc_mock_gov_notify import app
 
 
-def before_scenario(context, _step):
+def before_feature(context, _step):
+    port = os.getenv("PORT", 3001)
+    host = 'localhost'
+    command = f'pipenv run gunicorn -b {host}:{port} --workers 1 --timeout 60 sdc_mock_gov_notify:app'
+    context.app_url = f'http://{host}:{port}'
+
+    print(f'Starting server with command {command}')
     app.testing = True
-    context.app = app.test_client()
+    context.process = subprocess.Popen(command, shell=True)
+
+    _wait_for_server(f'{context.app_url}/inbox/emails', retries=10)
+
+
+def after_feature(context, _scenario):
+    context.process.terminate()
+
+
+def _wait_for_server(test_url, retries):
+    print('Waiting for server to start')
+    started = False
+    while (not started) and retries > 1:
+        try:
+            response = requests.get(test_url, timeout=30)
+            if response.status_code == requests.codes.ok:
+                started = True
+            else:
+                print('retrying')
+
+        except:
+            print(f'retrying...')
+            sleep(1)
+            retries -= 1
+    if not started:
+        raise Exception('Failed to start server')
+    print('Server started')

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -2,19 +2,22 @@ from behave import *
 
 import requests
 from nose.tools import assert_equals
+from notifications_python_client import NotificationsAPIClient
 
 
 @given(u'an email is sent to Gov Notify to "{email_address}"')
 def send_email_to_gov_notify(context, email_address):
+    service_id = 'S' * 32
+    api_id = 'A' * 32
+    api_key = api_id + service_id
 
-    response = requests.post(
-        f'{context.app_url}/gov_notify_api/v2/notifications/email',
-        json={'email_address': email_address,
-              'template_id': 'this-is-a-uuid',
-              'personalisation': {'name': 'Tom'},
-              'reference': 'example-reference'})
+    client = NotificationsAPIClient(api_key, base_url=f'{context.app_url}')
 
-    assert_equals(200, response.status_code)
+    client.send_email_notification(
+        email_address=email_address,
+        template_id='this-is-a-uuid',
+        personalisation={'name': 'Tom'},
+        reference='example-reference')
 
 
 @when(u'I check the email inbox')

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,35 +1,35 @@
-import json
+from behave import *
+
+import requests
 from nose.tools import assert_equals
 
 
 @given(u'an email is sent to Gov Notify to "{email_address}"')
 def send_email_to_gov_notify(context, email_address):
 
-    response = context.app.post(
-        '/gov_notify_api/v2/notifications/email',
-        data=json.dumps({'email_address': email_address,
-                         'template_id': 'this-is-a-uuid',
-                         'personalisation': {'name': 'Tom'},
-                         'reference': 'example-reference'}),
-        content_type='application/json')
+    response = requests.post(
+        f'{context.app_url}/gov_notify_api/v2/notifications/email',
+        json={'email_address': email_address,
+              'template_id': 'this-is-a-uuid',
+              'personalisation': {'name': 'Tom'},
+              'reference': 'example-reference'})
 
     assert_equals(200, response.status_code)
 
 
 @when(u'I check the email inbox')
 def check_inbox(context):
-    response = context.app.get('/inbox/emails')
+    response = requests.get(f'{context.app_url}/inbox/emails')
 
     assert_equals(200, response.status_code)
 
-    context.emails = json.loads(response.data)
+    context.emails = response.json()
     print(context.emails)
 
 
 @when(u'I clear the email inbox')
 def clear_inbox(context):
-    response = context.app.delete('/inbox/emails')
-
+    response = requests.delete(f'{context.app_url}/inbox/emails')
     assert_equals(200, response.status_code)
 
 

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -17,14 +17,17 @@ def send_email():
     template_id = 'https://api.notifications.service.gov.uk/templates/' + \
                   data["template_id"]
 
-    response = {'notificationId': str(uuid.uuid4()),
+    response = {'id': str(uuid.uuid4()),
                 'reference': data['reference'],
-                'templateVersion': 1,
-                'templateId': data['template_id'],
-                'templateUri': template_id,
-                'body': json.dumps(data),
-                'subject': 'An example subject'
+                'template': {
+                    'version': 1,
+                    'id': data['template_id'],
+                    'uri': template_id},
+                'content': {
+                    'body': json.dumps(data),
+                    'subject': 'An example subject'}
                 }
+
     return Response(response=json.dumps(response),
                     status=201, mimetype='application/json')
 

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -1,3 +1,5 @@
+import uuid
+
 from flask import Flask, request, Response
 import json
 
@@ -11,7 +13,16 @@ def send_email():
     data = json.loads(request.data)
 
     emails.append(data)
-    return Response(response="{}", status=200, mimetype="application/json")
+
+    response = {'notificationId': str(uuid.uuid4()),
+                'reference': data['reference'],
+                'templateVersion': 1,
+                'templateId': data['template_id'],
+                'templateUri': f'https://api.notifications.service.gov.uk/templates/{data["template_id"]}',
+                'body': json.dumps(data),
+                'subject': 'An example subject'
+                }
+    return Response(response=json.dumps(response), status=200, mimetype='application/json')
 
 
 @app.route('/inbox/emails', methods=['GET'])

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -6,7 +6,7 @@ app = Flask(__name__)
 emails = []
 
 
-@app.route('/gov_notify_api/v2/notifications/email', methods=['POST'])
+@app.route('/v2/notifications/email', methods=['POST'])
 def send_email():
     data = json.loads(request.data)
 

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -26,7 +26,7 @@ def send_email():
                 'subject': 'An example subject'
                 }
     return Response(response=json.dumps(response),
-                    status=200, mimetype='application/json')
+                    status=201, mimetype='application/json')
 
 
 @app.route('/inbox/emails', methods=['GET'])

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -40,4 +40,4 @@ def get_emails():
 @app.route('/inbox/emails', methods=['DELETE'])
 def clear_emails():
     emails.clear()
-    return 'OK', 200
+    return json.dumps({'success': True}), 200

--- a/sdc_mock_gov_notify/app.py
+++ b/sdc_mock_gov_notify/app.py
@@ -14,15 +14,19 @@ def send_email():
 
     emails.append(data)
 
+    template_id = 'https://api.notifications.service.gov.uk/templates/' + \
+                  data["template_id"]
+
     response = {'notificationId': str(uuid.uuid4()),
                 'reference': data['reference'],
                 'templateVersion': 1,
                 'templateId': data['template_id'],
-                'templateUri': f'https://api.notifications.service.gov.uk/templates/{data["template_id"]}',
+                'templateUri': template_id,
                 'body': json.dumps(data),
                 'subject': 'An example subject'
                 }
-    return Response(response=json.dumps(response), status=200, mimetype='application/json')
+    return Response(response=json.dumps(response),
+                    status=200, mimetype='application/json')
 
 
 @app.route('/inbox/emails', methods=['GET'])

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -31,9 +31,23 @@ class AppTest(unittest.TestCase):
         response = self._send_email_request()
         self.assertIsInstance(response, dict)
 
-    def test_send_email_returns_templateVersion_of_1(self):
+    def test_send_email_returns_notification_id_as_a_UUID(self):
         response = self._send_email_request()
-        self.assertEqual(1, response['templateVersion'])
+        self.assertUUID(response['id'])
+
+    def test_send_email_returns_unique_notification_ids(self):
+        uuid1 = self._send_email_request()['id']
+        uuid2 = self._send_email_request()['id']
+
+        self.assertNotEqual(uuid1, uuid2)
+
+    def test_send_email_returns_a_template_dict(self):
+        response = self._send_email_request()
+        self.assertIsInstance(response['template'], dict)
+
+    def test_send_email_returns_template_version_of_1(self):
+        response = self._send_email_request()
+        self.assertEqual(1, response['template']['version'])
 
     def test_send_email_returns_the_provided_reference(self):
         response = self._send_email_request({'reference': 'this-reference'})
@@ -47,17 +61,13 @@ class AppTest(unittest.TestCase):
         response = self._send_email_request(override)
         self.assertEqual(
             '56f9c46c-4672-4cf7-80bf-1f9265e42fba',
-            response['templateId'])
+            response['template']['id'])
 
         override = {'template_id': '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7'}
         response = self._send_email_request(override)
         self.assertEqual(
             '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7',
-            response['templateId'])
-
-    def test_send_email_returns_notificationId_as_a_UUID(self):
-        response = self._send_email_request()
-        self.assertUUID(response['notificationId'])
+            response['template']['id'])
 
     def test_send_email_returns_a_template_URI_with_template_id(self):
         override = {'template_id': '915ceb17-de9b-466c-beeb-25c9e49a1aa4'}
@@ -65,30 +75,28 @@ class AppTest(unittest.TestCase):
         self.assertEqual(
             'https://api.notifications.service.gov.uk/templates/'
             '915ceb17-de9b-466c-beeb-25c9e49a1aa4',
-            response['templateUri'])
+            response['template']['uri'])
 
         override = {'template_id': 'd92c7ae3-d9c9-454d-8401-cf6bb4c35581'}
         response = self._send_email_request(override)
         self.assertEqual(
             'https://api.notifications.service.gov.uk/templates/'
             'd92c7ae3-d9c9-454d-8401-cf6bb4c35581',
-            response['templateUri'])
+            response['template']['uri'])
+
+    def test_send_email_returns_a_content_dict(self):
+        response = self._send_email_request()
+        self.assertIsInstance(response['content'], dict)
 
     def test_send_email_returns_the_body_containing_the_requested_JSON(self):
         response = self._send_email_request()
         self.assertEqual(
             self.VALID_SEND_EMAIL_REQUEST,
-            json.loads(response['body']))
+            json.loads(response['content']['body']))
 
     def test_send_email_returns_a_static_subject(self):
         response = self._send_email_request()
-        self.assertEqual('An example subject', response['subject'])
-
-    def test_send_email_returns_unique_notification_ids(self):
-        uuid1 = self._send_email_request()['notificationId']
-        uuid2 = self._send_email_request()['notificationId']
-
-        self.assertNotEqual(uuid1, uuid2)
+        self.assertEqual('An example subject', response['content']['subject'])
 
     def _send_email_request(self, override={}):
         data = self.VALID_SEND_EMAIL_REQUEST.copy()

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,0 +1,86 @@
+import json
+import unittest
+from uuid import UUID
+
+from sdc_mock_gov_notify import app
+
+
+class AppTest(unittest.TestCase):
+    TEMPLATE_ID = '288de68c-f407-4290-92d8-97d84d885e44'
+    VALID_SEND_EMAIL_REQUEST = {'email_address': 'tom@example.com',
+                                'template_id': TEMPLATE_ID,
+                                'personalisation': {'name': 'Tom'},
+                                'reference': 'example-reference'}
+
+    def setUp(self):
+        app.testing = True
+        self.app = app.test_client()
+
+    def assertUUID(self, string):
+        UUID(string)
+
+    def test_send_email_returns_a_200_status_code(self):
+        response = self.app.post(
+            '/v2/notifications/email',
+            data=json.dumps(self.VALID_SEND_EMAIL_REQUEST),
+            content_type='application/json')
+
+        self.assertEqual(200, response.status_code)
+
+    def test_send_email_returns_a_valid_JSON_object(self):
+        response = self._send_email_request()
+        self.assertIsInstance(response, dict)
+
+    def test_send_email_returns_templateVersion_of_1(self):
+        response = self._send_email_request()
+        self.assertEqual(1, response['templateVersion'])
+
+    def test_send_email_returns_the_provided_reference(self):
+        response = self._send_email_request({'reference': 'this-reference'})
+        self.assertEqual('this-reference', response['reference'])
+
+        response = self._send_email_request({'reference': 'another-reference'})
+        self.assertEqual('another-reference', response['reference'])
+
+    def test_send_email_returns_the_provided_template_id(self):
+        response = self._send_email_request({'template_id': '56f9c46c-4672-4cf7-80bf-1f9265e42fba'})
+        self.assertEqual('56f9c46c-4672-4cf7-80bf-1f9265e42fba', response['templateId'])
+
+        response = self._send_email_request({'template_id': '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7'})
+        self.assertEqual('92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7', response['templateId'])
+
+    def test_send_email_returns_notificationId_as_a_UUID(self):
+        response = self._send_email_request()
+        self.assertUUID(response['notificationId'])
+
+    def test_send_email_returns_a_template_URI_containing_the_template_id(self):
+        response = self._send_email_request({'template_id': '915ceb17-de9b-466c-beeb-25c9e49a1aa4'})
+        self.assertEqual('https://api.notifications.service.gov.uk/templates/915ceb17-de9b-466c-beeb-25c9e49a1aa4', response['templateUri'])
+
+        response = self._send_email_request({'template_id': 'd92c7ae3-d9c9-454d-8401-cf6bb4c35581'})
+        self.assertEqual('https://api.notifications.service.gov.uk/templates/d92c7ae3-d9c9-454d-8401-cf6bb4c35581', response['templateUri'])
+
+    def test_send_email_returns_the_response_containing_the_requested_JSON(self):
+        response = self._send_email_request()
+        self.assertEqual(self.VALID_SEND_EMAIL_REQUEST, json.loads(response['body']))
+
+    def test_send_email_returns_a_static_subject(self):
+        response = self._send_email_request()
+        self.assertEqual('An example subject', response['subject'])
+
+    def test_send_email_returns_unique_notification_ids(self):
+        uuid1 = self._send_email_request()['notificationId']
+        uuid2 = self._send_email_request()['notificationId']
+
+        self.assertNotEqual(uuid1, uuid2)
+
+    def _send_email_request(self, override={}):
+        data = self.VALID_SEND_EMAIL_REQUEST.copy()
+        data.update(override)
+
+        response = self.app.post(
+            '/v2/notifications/email',
+            data=json.dumps(data),
+            content_type='application/json')
+        body = json.loads(response.data)
+        return body

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -25,7 +25,7 @@ class AppTest(unittest.TestCase):
             data=json.dumps(self.VALID_SEND_EMAIL_REQUEST),
             content_type='application/json')
 
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(201, response.status_code)
 
     def test_send_email_returns_a_valid_JSON_object(self):
         response = self._send_email_request()

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -43,26 +43,42 @@ class AppTest(unittest.TestCase):
         self.assertEqual('another-reference', response['reference'])
 
     def test_send_email_returns_the_provided_template_id(self):
-        response = self._send_email_request({'template_id': '56f9c46c-4672-4cf7-80bf-1f9265e42fba'})
-        self.assertEqual('56f9c46c-4672-4cf7-80bf-1f9265e42fba', response['templateId'])
+        override = {'template_id': '56f9c46c-4672-4cf7-80bf-1f9265e42fba'}
+        response = self._send_email_request(override)
+        self.assertEqual(
+            '56f9c46c-4672-4cf7-80bf-1f9265e42fba',
+            response['templateId'])
 
-        response = self._send_email_request({'template_id': '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7'})
-        self.assertEqual('92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7', response['templateId'])
+        override = {'template_id': '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7'}
+        response = self._send_email_request(override)
+        self.assertEqual(
+            '92276bc9-1b88-42ff-8a0a-8a0bcdaf43e7',
+            response['templateId'])
 
     def test_send_email_returns_notificationId_as_a_UUID(self):
         response = self._send_email_request()
         self.assertUUID(response['notificationId'])
 
-    def test_send_email_returns_a_template_URI_containing_the_template_id(self):
-        response = self._send_email_request({'template_id': '915ceb17-de9b-466c-beeb-25c9e49a1aa4'})
-        self.assertEqual('https://api.notifications.service.gov.uk/templates/915ceb17-de9b-466c-beeb-25c9e49a1aa4', response['templateUri'])
+    def test_send_email_returns_a_template_URI_with_template_id(self):
+        override = {'template_id': '915ceb17-de9b-466c-beeb-25c9e49a1aa4'}
+        response = self._send_email_request(override)
+        self.assertEqual(
+            'https://api.notifications.service.gov.uk/templates/'
+            '915ceb17-de9b-466c-beeb-25c9e49a1aa4',
+            response['templateUri'])
 
-        response = self._send_email_request({'template_id': 'd92c7ae3-d9c9-454d-8401-cf6bb4c35581'})
-        self.assertEqual('https://api.notifications.service.gov.uk/templates/d92c7ae3-d9c9-454d-8401-cf6bb4c35581', response['templateUri'])
+        override = {'template_id': 'd92c7ae3-d9c9-454d-8401-cf6bb4c35581'}
+        response = self._send_email_request(override)
+        self.assertEqual(
+            'https://api.notifications.service.gov.uk/templates/'
+            'd92c7ae3-d9c9-454d-8401-cf6bb4c35581',
+            response['templateUri'])
 
-    def test_send_email_returns_the_response_containing_the_requested_JSON(self):
+    def test_send_email_returns_the_body_containing_the_requested_JSON(self):
         response = self._send_email_request()
-        self.assertEqual(self.VALID_SEND_EMAIL_REQUEST, json.loads(response['body']))
+        self.assertEqual(
+            self.VALID_SEND_EMAIL_REQUEST,
+            json.loads(response['body']))
 
     def test_send_email_returns_a_static_subject(self):
         response = self._send_email_request()

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -111,9 +111,10 @@ class AppTest(unittest.TestCase):
         self._send_email_request({'reference': 'email2'})
 
         response = self.app.get('/inbox/emails')
-        self.assertEqual([self._valid_email_request_with({'reference': 'email1'}),
-                          self._valid_email_request_with({'reference': 'email2'})],
-                         json.loads(response.data))
+
+        request1 = self._valid_email_request_with({'reference': 'email1'})
+        request2 = self._valid_email_request_with({'reference': 'email2'})
+        self.assertEqual([request1, request2], json.loads(response.data))
 
     def test_delete_emails_returns_a_200_status_code(self):
         response = self.app.delete('/inbox/emails')


### PR DESCRIPTION
# Motivation and Context
The Java client was throwing errors because the mock return was not valid.

# What has changed
A whole lot of stuff:
- Return a valid JSON response from the send email endpoint
- Return a 201 status code
- Add Travis config
- Add pull request template
